### PR TITLE
Improve CI for Python

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,19 +6,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-    - name: Dry-run training
-      run: |
-        python train_caption.py --dry-run
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - name: Check Python syntax
+        run: |
+          python -m py_compile $(git ls-files '*.py')
+      - name: Run tests
+        run: |
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -ra
+      - name: Dry-run training
+        run: |
+          python train_caption.py --dry-run


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to cache pip packages
- run flake8, py_compile, pytest, and a dry-run training command

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd8b542608321a6d1e8420b614086